### PR TITLE
fix: hardcoded username in prompt

### DIFF
--- a/Prompt.ps1
+++ b/Prompt.ps1
@@ -68,7 +68,7 @@ Function Prompt {
         }
     } 
 
-    Write-Host "LePichu@Toaster " -NoNewLine -ForegroundColor DarkCyan
+    Write-Host "$Env:USERNAME " -NoNewLine -ForegroundColor DarkCyan
     Write-Host "in " -NoNewLine 
     Write-Host "$(Split-Path -Leaf (Get-Location))" -NoNewLine -ForegroundColor Blue
     Write-Host $LANGS 


### PR DESCRIPTION
the name of user was hardcoded 👍 